### PR TITLE
feat: add configurable queryTimeout to abort hung queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,24 +65,41 @@ Add in [config.json]:
 }
 ```
 
+A `queryTimeout` (in milliseconds) set here applies to **every** query run through this executor (it can still be overridden per query in the plan):
+
+```json
+{
+  "id": "mysql_default",
+  "type": "@runnerty-executor-mysql",
+  "user": "mysqlusr",
+  "password": "mysqlpass",
+  "database": "MYDB",
+  "host": "myhost.com",
+  "port": "3306",
+  "queryTimeout": 30000
+}
+```
+
 #### Configuration params:
 
-| Parameter          | Description                                                                                                 |
-| :----------------- | :---------------------------------------------------------------------------------------------------------- |
-| user               | The MySQL user to authenticate as.                                                                          |
-| password           | The password of that MySQL user.                                                                            |
-| database           | Name of the database to use for this connection. (Optional)                                                 |
-| host               | The hostname of the database you are connecting to.                                                         |
-| port               | The port number to connect to. (Default: 3306)                                                              |
-| socketPath         | The path to a unix domain socket to connect to. When used host and port are ignored. (Optional)             |
-| charset            | The charset for the connection (collation). (Default: 'UTF8_GENERAL_CI')                                    |
-| timezone           | The timezone configured on the MySQL server. (Default: 'local')                                             |
-| insecureAuth       | Allow connecting to MySQL instances that ask for the old (insecure) authentication method. (Default: false) |
-| flags              | Connection flags. More information [here](https://github.com/mysqljs/mysql#connection-flags).               |
-| multipleStatements | Allow multiple mysql statements per query. (Default: true)                                                  |
-| ssl/ca             | SSL CA File (Optional)                                                                                      |
-| ssl/cert           | SSL CERT File (Optional)                                                                                    |
-| ssl/key            | SSL KEY File (Optional)                                                                                     |
+| Parameter          | Description                                                                                                                                                                                                                                                                                                                                                                                                  |
+| :----------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| user               | The MySQL user to authenticate as.                                                                                                                                                                                                                                                                                                                                                                           |
+| password           | The password of that MySQL user.                                                                                                                                                                                                                                                                                                                                                                             |
+| database           | Name of the database to use for this connection. (Optional)                                                                                                                                                                                                                                                                                                                                                  |
+| host               | The hostname of the database you are connecting to.                                                                                                                                                                                                                                                                                                                                                          |
+| port               | The port number to connect to. (Default: 3306)                                                                                                                                                                                                                                                                                                                                                               |
+| socketPath         | The path to a unix domain socket to connect to. When used host and port are ignored. (Optional)                                                                                                                                                                                                                                                                                                              |
+| charset            | The charset for the connection (collation). (Default: 'UTF8_GENERAL_CI')                                                                                                                                                                                                                                                                                                                                     |
+| timezone           | The timezone configured on the MySQL server. (Default: 'local')                                                                                                                                                                                                                                                                                                                                              |
+| insecureAuth       | Allow connecting to MySQL instances that ask for the old (insecure) authentication method. (Default: false)                                                                                                                                                                                                                                                                                                  |
+| flags              | Connection flags. More information [here](https://github.com/mysqljs/mysql#connection-flags).                                                                                                                                                                                                                                                                                                                |
+| multipleStatements | Allow multiple mysql statements per query. (Default: true)                                                                                                                                                                                                                                                                                                                                                   |
+| connectTimeout     | Milliseconds before a timeout occurs during the initial connection to the MySQL server. (Default: 60000)                                                                                                                                                                                                                                                                                                     |
+| queryTimeout       | Milliseconds before an unresponsive query is aborted with a timeout error. Prevents a hung query from blocking the chain forever — e.g. when the server silently drops an idle/pooled connection and mysql2 reports it only as a non-fatal "packets out of order" warning. Disabled by default (no timeout). Applies to every query of this executor and can be overridden per query in the plan. (Optional) |
+| ssl/ca             | SSL CA File (Optional)                                                                                                                                                                                                                                                                                                                                                                                       |
+| ssl/cert           | SSL CERT File (Optional)                                                                                                                                                                                                                                                                                                                                                                                     |
+| ssl/key            | SSL KEY File (Optional)                                                                                                                                                                                                                                                                                                                                                                                      |
 
 ### Plan sample:
 
@@ -99,6 +116,16 @@ Add in [plan.json]:
 {
   "id": "mysql_default",
   "command": "SELECT NOW()"
+}
+```
+
+Overriding the timeout for a single query (in milliseconds) with `queryTimeout`. This takes precedence over the executor-level `queryTimeout`:
+
+```json
+{
+  "id": "mysql_default",
+  "command": "SELECT NOW()",
+  "queryTimeout": 30000
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -40,6 +40,17 @@ class mysqlExecutor extends Executor {
       sql: query
     };
 
+    // Optional per-query timeout (in milliseconds), mapped to mysql2's native
+    // query `timeout`. It guards against a query that never settles: e.g. when
+    // the database server silently drops an idle/pooled connection, mysql2 may
+    // emit only a non-fatal "packets out of order" warning instead of an error,
+    // leaving the query — and therefore the whole Runnerty chain — hung forever.
+    // When set, mysql2 raises a PROTOCOL_SEQUENCE_TIMEOUT error on expiry, which
+    // is handled by the `error` listeners below so the process always ends.
+    if (params.queryTimeout) {
+      queryOptions.timeout = params.queryTimeout;
+    }
+
     if (params.localInFile) {
       if (fs.existsSync(params.localInFile)) {
         queryOptions.infileStreamFactory = () => {
@@ -304,6 +315,10 @@ class mysqlExecutor extends Executor {
   }
 
   _error(errMsg) {
+    // Settle only once: a hung query recovered via `queryTimeout` can surface an
+    // error from both the query stream and the pool-level `error` listener.
+    if (this.ended) return;
+    this.ended = true;
     this.endOptions.end = 'error';
     this.endOptions.messageLog = errMsg || this.endOptions.messageLog;
     this.endOptions.err_output = errMsg || this.endOptions.err_output;

--- a/schema.json
+++ b/schema.json
@@ -57,6 +57,9 @@
         "connectTimeout": {
           "type": "number"
         },
+        "queryTimeout": {
+          "type": "number"
+        },
         "dateStrings": {
           "type": ["boolean", "string"]
         },
@@ -112,6 +115,9 @@
             "command": {
               "type": "string"
             },
+            "queryTimeout": {
+              "type": "number"
+            },
             "args": {
               "type": "object"
             },
@@ -144,6 +150,9 @@
             },
             "command_file": {
               "type": "string"
+            },
+            "queryTimeout": {
+              "type": "number"
             },
             "args": {
               "type": "object"


### PR DESCRIPTION
## Summary

Adds an optional **`queryTimeout`** parameter (in milliseconds) that aborts a query which never responds, so a hung query can no longer block a Runnerty chain indefinitely. It maps directly to mysql2's native per-query `timeout`, so on expiry mysql2 raises a `PROTOCOL_SEQUENCE_TIMEOUT` error that the executor's existing `error` listeners already handle.

## Problem

When the database server silently drops an idle or pooled connection (e.g. MySQL `wait_timeout`), mysql2 does **not** always surface this as an error. In several cases it only emits a non-fatal warning:

```
Warning: got packets out of order. Expected 2 but received 1
```

and then keeps going. The in-flight query never emits `end` or `error`, so:

- the executor never calls `end()`,
- the process never finishes,
- and because Runnerty won't start a new instance of a chain whose previous run is still "running", **every subsequent scheduled run is silently skipped** until the process is restarted.

There is no per-run error and no notification — the chain just goes quiet. mysql2 itself considers the "packets out of order" condition a warning and does not plan to change it (it is the same in the latest release), and the maintainers consider query timeouts out of scope for the driver core — so the guard has to live in the executor.

## Fix

- Map a new optional `queryTimeout` (ms) onto mysql2's query `timeout`. When set, an unresponsive query is aborted with a `PROTOCOL_SEQUENCE_TIMEOUT` error, which flows through the existing `error` handlers and ends the process cleanly.
- Guard `_error()` so the process settles **exactly once** (a recovered hang can surface an error from both the query stream and the pool-level `error` listener).
- Document the option in the README and `schema.json`.
- Backwards compatible and opt-in: with no `queryTimeout` set, behaviour is unchanged.

This was verified locally against a real mysql2 server that completes the handshake and then never answers the query (which reproduces the exact `Warning: got packets out of order` condition): without `queryTimeout` the process hangs forever; with it, mysql2 aborts the query and the executor ends with `end: 'error'` within the timeout window.

## Usage

```json
{
  "id": "mysql_default",
  "command": "SELECT NOW()",
  "queryTimeout": 30000
}
```

---

## Resumen (ES)

Añade un parámetro opcional **`queryTimeout`** (en milisegundos) que aborta una query que no responde, de modo que una query colgada ya no pueda bloquear indefinidamente una cadena de Runnerty. Se mapea directamente al `timeout` nativo de mysql2: al expirar, mysql2 lanza un error `PROTOCOL_SEQUENCE_TIMEOUT` que ya gestionan los listeners de `error` existentes del executor.

### Problema

Cuando el servidor de base de datos cierra en silencio una conexión ociosa o del pool (p. ej. por `wait_timeout` de MySQL), mysql2 **no** siempre lo reporta como error. En varios casos solo emite un aviso no fatal:

```
Warning: got packets out of order. Expected 2 but received 1
```

y continúa. La query en curso nunca emite `end` ni `error`, así que el executor nunca llama a `end()`, el proceso no termina y —como Runnerty no arranca una nueva instancia de una cadena cuya ejecución anterior sigue "en curso"— **todas las ejecuciones programadas posteriores se saltan en silencio** hasta reiniciar el proceso. No hay error por ejecución ni notificación: la cadena simplemente deja de funcionar. mysql2 considera el "packets out of order" un aviso (sigue igual en la última versión) y el timeout de query queda fuera del alcance del driver, por lo que la protección debe estar en el executor.

### Solución

- Mapear el nuevo `queryTimeout` (ms) al `timeout` de query de mysql2. Si se define, una query que no responde se aborta con `PROTOCOL_SEQUENCE_TIMEOUT`, que pasa por los manejadores de `error` existentes y cierra el proceso limpiamente.
- Proteger `_error()` para que el proceso cierre **una sola vez** (una recuperación puede generar error tanto en el stream de la query como en el listener `error` del pool).
- Documentar la opción en README y `schema.json`.
- Compatible hacia atrás y opt-in: sin `queryTimeout`, el comportamiento no cambia.

Verificado localmente contra un servidor mysql2 real que completa el handshake y luego nunca responde la query (reproduce el mismo `Warning: got packets out of order`): sin `queryTimeout` el proceso se cuelga indefinidamente; con él, mysql2 aborta y el executor cierra con `end: 'error'` dentro de la ventana del timeout.
