### PR TITLE
release: 3.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@runnerty/executor-mysql",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@runnerty/executor-mysql",
-      "version": "3.2.1",
+      "version": "3.3.0",
       "license": "MIT",
       "dependencies": {
         "@runnerty/module-core": "~3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runnerty/executor-mysql",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "Runnerty module: MySQL executor",
   "author": "Runnerty Tech",
   "license": "MIT",


### PR DESCRIPTION
## Release 3.3.0

Version bump `3.2.1` → `3.3.0` to publish the changes already merged into `main`:

- **#30** `feat: add configurable queryTimeout to abort hung queries` — a query that never settles (e.g. a server-dropped idle connection that mysql2 only reports as a non-fatal "packets out of order" warning) no longer blocks the chain forever.
- **#31** `chore: bump mysql2 to ~3.22.5`.

Minor bump (a new feature is included). No code changes in this PR — only `package.json` / `package-lock.json`.

After merge: tag `3.3.0` and `npm publish`.

---

## Release 3.3.0 (ES)

Subida de versión `3.2.1` → `3.3.0` para publicar lo ya mergeado en `main`:

- **#30** `feat: add configurable queryTimeout to abort hung queries` — una query que nunca resuelve (p. ej. una conexión ociosa que el servidor cierra y mysql2 solo reporta como aviso no fatal "packets out of order") deja de bloquear la cadena indefinidamente.
- **#31** `chore: bump mysql2 to ~3.22.5`.

Bump minor (incluye una feature nueva). Sin cambios de código en este PR — solo `package.json` / `package-lock.json`.

Tras el merge: tag `3.3.0` y `npm publish`.
